### PR TITLE
Use absolute foreign amount value

### DIFF
--- a/src/migrator/transaction_map.rs
+++ b/src/migrator/transaction_map.rs
@@ -80,7 +80,7 @@ pub fn convert_up_bank_transaction_to_fire_fly(
 
     match &up_bank_transaction.attributes.foreign_amount {
         Some(foriegn_amount) => {
-            fire_fly_transaction.foreign_amount = Some(foriegn_amount.value.clone());
+            fire_fly_transaction.foreign_amount = Some(foriegn_amount.value.clone().replace('-', ""));
             fire_fly_transaction.foreign_currency_code = Some(foriegn_amount.currency_code.clone());
         }
         None => fire_fly_transaction.foreign_amount = Some("0".to_string()),


### PR DESCRIPTION
This caused issues when the `foreign_amount` is shown as a negative value. Updating it to use the absolute value.

Example of the failure:

```
   0: Failed to submit transaction(TransactionPayload { transaction_type: "withdrawal", ... foreign_amount: Some("-6.00") ... }), error code: 422 Unprocessable Entity, error: {"message":"The value must be zero or more.","errors":{"transactions.0.foreign_amount":["The value must be zero or more."]}}
```

After this change, the import worked as expected.