### PR TITLE
fix: handle null opening_balance from Firefly III API

### DIFF
--- a/src/fire_fly/accounts.rs
+++ b/src/fire_fly/accounts.rs
@@ -43,7 +43,7 @@ pub struct Attributes {
     pub iban: Option<String>,
     pub bic: Option<String>,
     pub account_number: Option<String>,
-    pub opening_balance: String,
+    pub opening_balance: Option<String>,
     pub current_debt: Option<String>,
     pub opening_balance_date: Option<String>,
     pub virtual_balance: String,


### PR DESCRIPTION
Firefly III can return null for opening_balance on accounts that have no opening balance set. 

When running the import, a null bank account would throw an error and cause the importer to fail

The field was typed as String which caused the balance to always include the opening balance. Changed to Option<String> to handle this case.